### PR TITLE
cuda-torch has no tag for latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a base docker image that contains torch and cutorch.
-FROM kaixhin/cuda-torch
+FROM kaixhin/cuda-torch:8.0
 
 # Install fblualib and its dependencies :
 ADD install_all.sh /root/install_all.sh


### PR DESCRIPTION
The following happens:

```
docker build -t crnn_docker .
Sending build context to Docker daemon  309.2kB
Step 1/11 : FROM kaixhin/cuda-torch
manifest for kaixhin/cuda-torch:latest not found
```

There is somehow not `latest` tag for the cuda-torch repo. This commit locks the build to the latest version of cuda-torch (8.0).